### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ gunicorn==19.5.0
 psycopg2-binary
 redis==2.10.3
 requests==2.7.0
-six==1.10.0
+six==1.14.0
 websocket-client==0.35.0
 django-storages==1.6.6
 boto3==1.7.67
@@ -17,3 +17,4 @@ openpyxl
 pdfkit==0.6.1
 xvfbwrapper==0.2.9
 raven
+tablib==0.14.0


### PR DESCRIPTION
1. Update six for compatibility with newer pip
2. Add tablib to enable model import through admin page