### PR TITLE
Use pyppeteer instead of pdfkit to render PDFs

### DIFF
--- a/Translation/settings.py
+++ b/Translation/settings.py
@@ -29,15 +29,14 @@ DEBUG = True
 ALLOWED_HOSTS = ['*']
 USE_X_FORWARDED_HOST = True
 
-WKHTMLTOPDF_CMD_OPTIONS = {
-    'page-size': 'A4',
-    'margin-left': '0.75in',
-    'margin-right': '0.75in',
-    'margin-top': '0.62in',
-    'margin-bottom': '1in',
-    'print-media-type': '',
-    'no-stop-slow-scripts': '',
-    'javascript-delay': '30000',  # max wait until rendering finishes
+PYPPETEER_PDF_OPTIONS = {
+    'margin': {
+        'left': '0.75in',
+        'right': '0.75in',
+        'top': '0.62in',
+        'bottom': '1in',
+    },
+    'format': 'A4',
 }
 
 

--- a/Translation/settings.py
+++ b/Translation/settings.py
@@ -193,6 +193,8 @@ MONITOR_ADDRESS=os.environ.get('MONITOR_URL')
 DRAFT_PRINTER=os.environ.get('DRAFT_PRINTER')
 FINAL_PRINTER=os.environ.get('FINAL_PRINTER')
 
+PDF_RENDER_DELAY_SECS=int(os.environ.get('PDF_RENDER_DELAY_SECS', 5))
+
 
 STATIC_URL = '/static/'
 MEDIA_URL = '/media/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ ipython
 pytz
 django-websocket-redis
 openpyxl
-pdfkit==0.6.1
-xvfbwrapper==0.2.9
 raven
 tablib==0.14.0
+pyppeteer~=0.2.5

--- a/trans/utils/pdf.py
+++ b/trans/utils/pdf.py
@@ -110,7 +110,7 @@ async def convert_html_to_pdf(html, pdf_file_path):
         page = await browser.newPage()
         await page.goto('file://{}'.format(html_file_path))
         await page.emulateMedia('print')
-        await asyncio.sleep(5)
+        await asyncio.sleep(settings.PDF_RENDER_DELAY_SECS)
         await page.pdf({'path': pdf_file_path, **settings.PYPPETEER_PDF_OPTIONS})
         await browser.close()
         os.remove(html_file_path)

--- a/trans/utils/pdf.py
+++ b/trans/utils/pdf.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from urllib.parse import urljoin
 from uuid import uuid4
@@ -8,9 +9,8 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.template.loader import render_to_string
 
-import pdfkit
 from shutil import copyfile
-from xvfbwrapper import Xvfb
+from pyppeteer import launch
 
 from trans.context_processors import ioi_settings
 
@@ -78,7 +78,8 @@ def build_pdf(translation, task_type):
         images_path=settings.MEDIA_ROOT + 'images/',
         pdf_output=True,
     )
-    convert_html_to_pdf(html, pdf_file_path)
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(convert_html_to_pdf(html, pdf_file_path))
     add_page_numbers_to_pdf(pdf_file_path, task.name)
     return pdf_file_path
 
@@ -100,13 +101,18 @@ def pdf_response(pdf_file_path, file_name):
         return response
 
 
-def convert_html_to_pdf(html, pdf_file_path):
+async def convert_html_to_pdf(html, pdf_file_path):
     try:
         html_file_path = '/tmp/{}.html'.format(str(uuid4()))
         with open(html_file_path, 'wb') as f:
             f.write(html.encode('utf-8'))
-        with Xvfb():
-            pdfkit.from_file(html_file_path, pdf_file_path, options=settings.WKHTMLTOPDF_CMD_OPTIONS)
+        browser = await launch(options={'args': ['--no-sandbox']})
+        page = await browser.newPage()
+        await page.goto('file://{}'.format(html_file_path))
+        await page.emulateMedia('print')
+        await asyncio.sleep(5)
+        await page.pdf({'path': pdf_file_path, **settings.PYPPETEER_PDF_OPTIONS})
+        await browser.close()
         os.remove(html_file_path)
     except Exception as e:
         logger.error(e)


### PR DESCRIPTION
Pyppeteer is a Python port of [puppeteer](https://github.com/puppeteer/puppeteer), implementing API for headless chrome.