### PR TITLE
Add printBackground to pyppeteer options so that code block has background color

### DIFF
--- a/Translation/settings.py
+++ b/Translation/settings.py
@@ -37,6 +37,7 @@ PYPPETEER_PDF_OPTIONS = {
         'bottom': '1in',
     },
     'format': 'A4',
+    'printBackground': True,
 }
 PYPPETEER_PDF_RENDER_DELAY_SECS=int(os.environ.get('PYPPETEER_PDF_RENDER_DELAY_SECS', 5))
 


### PR DESCRIPTION
Ref: https://stackoverflow.com/questions/60736354/puppeteer-not-rendering-color-background-color-when-i-try-to-save-pdf-on-disk