### PR TITLE
Fix editor auto scrolling to the top when editing translation

### DIFF
--- a/trans/utils/edit_token.py
+++ b/trans/utils/edit_token.py
@@ -1,0 +1,37 @@
+from collections import namedtuple
+import datetime
+import random
+import string
+
+from django.core.cache import cache
+from django.conf import settings
+
+
+EditToken = namedtuple('EditToken', ['token', 'created_datetime'])
+
+
+def _trans_edit_cache_key(translation):
+    return 'TRANS_ET-%d' % translation.id
+
+
+def fetch_cached_edit_token(translation):
+    return cache.get(_trans_edit_cache_key(translation))
+
+
+def clear_cached_edit_token(translation):
+    cache.set(_trans_edit_cache_key(translation), None)
+
+
+def cache_edit_token(translation, edit_token):
+    if not isinstance(edit_token, EditToken):
+        raise TypeError('New edit_token must be an instance of EditToken')
+    cache.set(_trans_edit_cache_key(translation), edit_token)
+
+
+def is_edit_token_expired(edit_token, current_time):
+    return edit_token.created_datetime + datetime.timedelta(seconds=settings.TRANSLATION_EDIT_TIME_OUT) < current_time
+
+
+def generate_random_token():
+    return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+

--- a/trans/utils/translation.py
+++ b/trans/utils/translation.py
@@ -1,13 +1,6 @@
 import datetime
-import random
-import string
 
-from django.conf import settings
-from django.core.cache import cache
-
-
-def get_trans_edit_cache_key(translation):
-    return "TRANS_ET-%d" % translation.id
+from trans.utils import edit_token
 
 
 def get_task_by_contest_and_name(contest_slug, task_name, is_editor=False):
@@ -43,34 +36,39 @@ def get_requested_user(request, task_type):
     return user
 
 
-def get_translate_edit_permission(translation, my_token=None):
-    edit_token = cache.get(get_trans_edit_cache_key(translation))
+def get_translate_edit_permission(translation, user_token=None):
+    cached_edit_token = edit_token.fetch_cached_edit_token(translation)
     current_time = datetime.datetime.now()
 
-    if edit_token is None:
-        my_token = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
-        cache.set(get_trans_edit_cache_key(translation), (my_token, datetime.datetime.now()))
-        return True, my_token
-    elif my_token == edit_token[0] or edit_token[1] + datetime.timedelta(
-            seconds=settings.TRANSLATION_EDIT_TIME_OUT) < current_time:
-        cache.set(get_trans_edit_cache_key(translation), (my_token, datetime.datetime.now()))
-        return True, my_token
+    if cached_edit_token is None:
+        new_edit_token = edit_token.EditToken(edit_token.generate_random_token(), datetime.datetime.now())
+        edit_token.cache_edit_token(translation, new_edit_token)
+        return True, new_edit_token.token
+
+    if user_token == cached_edit_token.token or edit_token.is_edit_token_expired(cached_edit_token, current_time):
+        new_edit_token = edit_token.EditToken(user_token, datetime.datetime.now())
+        edit_token.cache_edit_token(translation, new_edit_token)
+        return True, new_edit_token.token
 
     return False, None
 
 
-def can_save_translate(translation, my_token):
-    edit_token = cache.get(get_trans_edit_cache_key(translation))
+def can_save_translate(translation, user_token):
+    cached_edit_token = edit_token.fetch_cached_edit_token(translation)
+    if cached_edit_token is None:
+        return True
+
     current_time = datetime.datetime.now()
-    return (edit_token is None) or my_token == edit_token[0] or edit_token[1] + datetime.timedelta(
-        seconds=settings.TRANSLATION_EDIT_TIME_OUT) < current_time
+    return user_token == cached_edit_token.token or edit_token.is_edit_token_expired(cached_edit_token, current_time)
 
 
 def is_translate_in_editing(translation):
     current_time = datetime.datetime.now()
-    edit_token = cache.get(get_trans_edit_cache_key(translation))
-    return (edit_token is not None) and (edit_token[1] + datetime.timedelta(seconds=settings.TRANSLATION_EDIT_TIME_OUT) > current_time)
+    cached_edit_token = edit_token.fetch_cached_edit_token(translation)
+    if cached_edit_token is None:
+        return False
+    return not edit_token.is_edit_token_expired(cached_edit_token, current_time)
 
 
 def unleash_edit_token(translation):
-    cache.set(get_trans_edit_cache_key(translation), None)
+    edit_token.clear_cached_edit_token(translation)

--- a/trans/utils/translation.py
+++ b/trans/utils/translation.py
@@ -45,8 +45,15 @@ def get_translate_edit_permission(translation, user_token=None):
         edit_token.cache_edit_token(translation, new_edit_token)
         return True, new_edit_token.token
 
-    if user_token == cached_edit_token.token or edit_token.is_edit_token_expired(cached_edit_token, current_time):
+    if user_token == cached_edit_token.token:
         new_edit_token = edit_token.EditToken(user_token, datetime.datetime.now())
+        edit_token.cache_edit_token(translation, new_edit_token)
+        return True, new_edit_token.token
+
+    # Older token shouldn't be reused once another token has been issued. Frontend can use this information
+    # to determine whether another translation editing session has happened.
+    if edit_token.is_edit_token_expired(cached_edit_token, current_time):
+        new_edit_token = edit_token.EditToken(edit_token.generate_random_token(), datetime.datetime.now())
         edit_token.cache_edit_token(translation, new_edit_token)
         return True, new_edit_token.token
 


### PR DESCRIPTION
The auto scroll issue is caused by edit token refresh operation that reloads the editor (see editor.js).

This PR implements two optimizations to reduce the number of editor reloads:

1. Disallow token reuse once another session has started. This causes editor reload to be unnecessary when token is the same after refresh.
2. Compare the translation text before reloading. This is more expensive than the previous token check, but this is done only when the token differs after refresh.

This also includes some cleanups in their own commits. Please let me know if you prefer the cleanups in a separate PR.