### PR TITLE
Expose printed draft pdfs

### DIFF
--- a/Translation/settings.py
+++ b/Translation/settings.py
@@ -209,6 +209,7 @@ STATIC_URL = '/static/'
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
 STATIC_ROOT = os.path.join(BASE_DIR, "static/")
+PRINTED_DRAFT_TRANSLATIONS_ROOT = os.path.join(BASE_DIR, 'draft_translations/')
 HOST_URL = 'http://127.0.0.1:9000/'
 
 PRINT_ENABLED = PRINT_SYSTEM_ADDRESS is not None

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -11,6 +11,7 @@ services:
     - .:/usr/src/app/ # Debugging
     - ioi_static:/usr/src/app/static/
     - ioi_media:/usr/src/app/media/
+    - ioi_draft_translations:/usr/src/app/draft_translations/
     depends_on:
     - postgres
     - redis
@@ -42,6 +43,7 @@ services:
     volumes:
     - ioi_static:/usr/src/app/static/:ro
     - ioi_media:/usr/src/app/media/:ro
+    - ioi_draft_translations:/usr/src/app/draft_translations/:ro
 
   postgres:
     restart: always
@@ -61,3 +63,4 @@ volumes:
   ioi_pgdata:
   ioi_static:
   ioi_media:
+  ioi_draft_translations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
     - ioi_static:/usr/src/app/static/
     - ioi_media:/usr/src/app/media/
+    - ioi_draft_translations:/usr/src/app/draft_translations/
     depends_on:
     - postgres
     - redis
@@ -38,6 +39,7 @@ services:
     volumes:
     - ioi_static:/usr/src/app/static/:ro
     - ioi_media:/usr/src/app/media/:ro
+    - ioi_draft_translations:/usr/src/app/draft_translations/:ro
 
   postgres:
     restart: always
@@ -57,3 +59,4 @@ volumes:
   ioi_pgdata:
   ioi_static:
   ioi_media:
+  ioi_draft_translations:

--- a/nginx/conf.d/ioi.conf
+++ b/nginx/conf.d/ioi.conf
@@ -11,8 +11,13 @@ server {
     location /static {
         alias /usr/src/app/static;
     }
-	location /media {
+
+    location /media {
         alias /usr/src/app/media;
+    }
+
+    location /draft_translations/ {
+    	alias /usr/src/app/draft_translations/;
     }
 	
     location / {

--- a/trans/utils/pdf.py
+++ b/trans/utils/pdf.py
@@ -126,9 +126,10 @@ def add_page_numbers_to_pdf(pdf_file_path, task_name):
     os.system(cmd)
 
 
-def add_info_line_to_pdf(pdf_file_path, info):
+def add_info_line_to_pdf(result_dir_path, pdf_file_path, info):
     color =  '-color "0.4 0.4 0.4" '
-    output_pdf_path = '/tmp/{}.pdf'.format(str(uuid4()))
+    output_pdf_path = '{}/{}.pdf'.format(result_dir_path, str(uuid4()))
+    os.makedirs(result_dir_path, exist_ok=True)
     cmd = 'cpdf -add-text "   {}" -font "Arial" -font-size 10 -bottomleft .62in {} -o {} {}'.format(
         info, pdf_file_path, output_pdf_path, color)
     os.system(cmd)

--- a/trans/views/translation.py
+++ b/trans/views/translation.py
@@ -191,11 +191,10 @@ class TranslationPrint(TranslationView):
         output_pdf_path = add_info_line_to_pdf(
             settings.PRINTED_DRAFT_TRANSLATIONS_ROOT, pdf_file_path, info_line)
 
-        # TODO(raisfathin): Send output_pdf_path to the job queue.
+        # TODO(raisfathin): Send output_pdf_path to the job queue (and remove the pdf later?).
 
         if translation.user == user and user.username != 'ISC':
             translation.save_last_version(release_note='Printed', saved=True)
-        os.remove(output_pdf_path)
         
         # For Monitor updates:
         if settings.MONITOR_ADDRESS:

--- a/trans/views/translation.py
+++ b/trans/views/translation.py
@@ -188,11 +188,10 @@ class TranslationPrint(TranslationView):
         else:
             #info_line = 'Printed at {}'.format(translation.get_latest_version().create_time.strftime("%H:%M"))
             info_line = 'Printed at {}'.format(datetime.datetime.now().strftime("%H:%M"))
-        output_pdf_path = add_info_line_to_pdf(pdf_file_path, info_line)
+        output_pdf_path = add_info_line_to_pdf(
+            settings.PRINTED_DRAFT_TRANSLATIONS_ROOT, pdf_file_path, info_line)
 
-#        send_pdf_to_printer(output_pdf_path, user.country.code, user.country.name, cover_page=False)
-        send_pdf_to_printer(output_pdf_path, user.country.code, user.country.name, settings.DRAFT_PRINTER)	
-
+        # TODO(raisfathin): Send output_pdf_path to the job queue.
 
         if translation.user == user and user.username != 'ISC':
             translation.save_last_version(release_note='Printed', saved=True)


### PR DESCRIPTION
Previously, printed draft pdfs were stored in /tmp then sent to printer. This PR moves the pdfs somewhere less transient and expose it.

This will make it easier to integrate properly with the job queue later as we wouldn't need nginx to expose /tmp.

Changes to prod nginx config will be done in a follow up PR.